### PR TITLE
fix: use _LDADD not _LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,10 +39,10 @@ SITEFILES_IMAGES = \
 bin_PROGRAMS = qrwork qrscq
 
 qrwork_SOURCES = qrwork.cc
-qrwork_LDFLAGS = -lgd
+qrwork_LDADD = -lgd
 
 qrscq_SOURCES = qrscq.cc
-qrscq_LDFLAGS = -lgd
+qrscq_LDADD = -lgd
 
 install-data-hook:
 	install -d $(prefix) $(prefix)/assets


### PR DESCRIPTION
As recommended by the automake manual (8.1.2 Linking the program),
the file `"Makefile.am"` should use `_LDADD` to pass `"-l"` linker flags.

https://www.gnu.org/software/automake/manual/html_node/Linking.html#Linking
